### PR TITLE
docs: comment the non-obvious parts of the rs-engine

### DIFF
--- a/pepmatch/rs-engine/src/lib.rs
+++ b/pepmatch/rs-engine/src/lib.rs
@@ -1,6 +1,11 @@
+//! PyO3 boundary: thin wrappers over `preprocess` (build a .pepidx) and `matching` (query
+//! one). Results are returned as tuples of parallel Vecs so matcher.py can feed each one
+//! straight into a polars Series instead of building per-row objects.
+
 use pyo3::prelude::*;
 
 mod preprocess;
+// `match` is a Rust keyword, so the file cannot be a module name; import it under an alias.
 #[path = "match.rs"]
 mod matching;
 

--- a/pepmatch/rs-engine/src/match.rs
+++ b/pepmatch/rs-engine/src/match.rs
@@ -1,8 +1,14 @@
+//! Query side: reads a `.pepidx` and reports where peptides occur. The index is mmapped and
+//! never copied, so searching is slicing into that mapping. Search modes: exact, mismatch
+//! (Hamming), indel, discontinuous, plus a counts-only variant of the mismatch path.
+
 use memmap2::Mmap;
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 
+// Both must match preprocess.rs. HEADER_SIZE is the byte width of the header fields:
+// magic, k, protein count, sequence length, k-mer count, positions, metadata length.
 const PROTEIN_INDEX_MULTIPLIER: u64 = 100_000_000;
 const HEADER_SIZE: usize = 8 + 1 + 4 + 8 + 8 + 8 + 8;
 
@@ -20,6 +26,8 @@ struct PepIndex {
     num_kmers: usize,
 }
 
+// Sound because the mapping is opened read-only and never mutated; the rayon workers in
+// `run*` only read it.
 unsafe impl Sync for PepIndex {}
 
 impl PepIndex {
@@ -82,6 +90,8 @@ impl PepIndex {
         Some(&self.mmap[start..end])
     }
 
+    /// The offset table entry for k-mer `i` points at
+    /// `[k bytes of k-mer][u32 count][count * u64 encoded position]` in the k-mer data.
     fn kmer_offset(&self, kmer_index: usize) -> usize {
         let pos = self.kmer_offsets_offset + kmer_index * 8;
         u64::from_le_bytes(self.mmap[pos..pos + 8].try_into().unwrap()) as usize
@@ -99,6 +109,8 @@ impl PepIndex {
         &self.mmap[data_start..data_start + count * 8]
     }
 
+    /// Binary search on raw bytes, which works because preprocess wrote the k-mers sorted and
+    /// all exactly k long.
     fn lookup(&self, kmer: &[u8]) -> Option<Vec<u64>> {
         let mut lo = 0usize;
         let mut hi = self.num_kmers;
@@ -132,6 +144,8 @@ impl PepIndex {
         (s, pos + 2 + len)
     }
 
+    /// In preprocess's write order: id, name, species, taxon, gene, PE level, sequence
+    /// version, gene priority, swissprot.
     fn get_metadata(&self, protein_number: usize) -> [String; 9] {
         let offset_pos = self.metadata_offsets_offset + (protein_number - 1) * 8;
         let meta_rel = u64::from_le_bytes(
@@ -159,6 +173,8 @@ fn exact_match(peptide: &str, k: usize, index: &PepIndex) -> Vec<u64> {
         return vec![];
     }
 
+    // Seeds: non-overlapping k-mer tiles plus the final k-mer, which together span every
+    // residue — so seeds agreeing on a start is equivalent to a full-length exact match.
     let num_kmers = pep_bytes.len() - k + 1;
     let mut target_indices: Vec<usize> = (0..num_kmers).step_by(k).collect();
     let last = num_kmers - 1;
@@ -170,6 +186,8 @@ fn exact_match(peptide: &str, k: usize, index: &PepIndex) -> Vec<u64> {
 
     let mut hit_counts: HashMap<u64, usize> = HashMap::new();
 
+    // Each hit votes for the start it implies (hit position minus the seed's offset in the
+    // peptide); only starts every seed voted for span the whole peptide.
     for &idx in &target_indices {
         let kmer = &pep_bytes[idx..idx + k];
         if let Some(positions) = index.lookup(kmer) {
@@ -188,6 +206,13 @@ fn exact_match(peptide: &str, k: usize, index: &PepIndex) -> Vec<u64> {
         .collect()
 }
 
+/// Verification helpers for the mismatch search: walk outward from a confirmed seed hit and
+/// accumulate mismatches, returning the sentinel 100 for "reject" (budget blown, or the
+/// alignment ran off a protein edge).
+///
+/// The `_neighbors` pair compares whole k-mer tiles, usable only when k divides the peptide
+/// length; the `_residues` pair walks overlapping k-mers comparing the single residue each
+/// contributes, which is what handles the lengths tiles cannot partition.
 fn check_left_neighbors(
     pep_bytes: &[u8], idx: usize, kmer_hit: u64, index: &PepIndex,
     k: usize, max_mismatches: usize, mut mismatches: usize,
@@ -253,6 +278,10 @@ fn check_right_residues(
     mismatches
 }
 
+/// Mismatch search -> (matched sequence, mismatch count, encoded start) per hit.
+///
+/// Seeding relies on the pigeonhole principle: within the mismatch budget at least one of the
+/// peptide's k-mers is exact, so every index hit is a candidate start, verified by extension.
 fn mismatch_match(peptide: &str, k: usize, max_mismatches: usize, index: &PepIndex) -> Vec<(String, usize, u64)> {
     let pep_bytes = peptide.as_bytes();
     if pep_bytes.len() < k { return vec![]; }
@@ -262,6 +291,8 @@ fn mismatch_match(peptide: &str, k: usize, max_mismatches: usize, index: &PepInd
     let mut matches: Vec<(String, usize, u64)> = Vec::new();
     let mut seen: HashSet<u64> = HashSet::new();
 
+    // k divides the length: disjoint tiles cover the peptide, so seeds step by k and
+    // verification compares whole tiles.
     if peptide_len % k == 0 {
         let mut idx = 0;
         while idx < num_kmers {
@@ -269,10 +300,13 @@ fn mismatch_match(peptide: &str, k: usize, max_mismatches: usize, index: &PepInd
             if let Some(positions) = index.lookup(kmer) {
                 for kmer_hit in positions {
                     let start = (kmer_hit as i64 - idx as i64) as u64;
+                    // Several seeds in one peptide imply the same start; keep one row each.
                     if seen.contains(&start) { continue; }
                     let mismatches = check_left_neighbors(pep_bytes, idx, kmer_hit, index, k, max_mismatches, 0);
                     let mismatches = check_right_neighbors(pep_bytes, idx, kmer_hit, index, k, max_mismatches, mismatches);
                     if mismatches <= max_mismatches {
+                        // Rebuild the database sequence tile by tile; a tile that fails to
+                        // resolve means the match would cross a protein boundary.
                         let mut matched = Vec::with_capacity(peptide_len);
                         let mut i = 0;
                         let mut valid = true;
@@ -293,6 +327,8 @@ fn mismatch_match(peptide: &str, k: usize, max_mismatches: usize, index: &PepInd
             idx += k;
         }
     } else {
+        // k does not divide the length, so tiles cannot partition the peptide: every offset
+        // is a seed and verification walks residue by residue.
         for idx in 0..num_kmers {
             let kmer = &pep_bytes[idx..idx + k];
             if let Some(positions) = index.lookup(kmer) {
@@ -306,6 +342,8 @@ fn mismatch_match(peptide: &str, k: usize, max_mismatches: usize, index: &PepInd
                         let mut i = 0;
                         let mut valid = true;
                         while i < peptide_len {
+                            // Final tile would overrun the peptide, so step `back` residues
+                            // earlier and keep only the tail we still need.
                             if i + k > peptide_len {
                                 let remaining = peptide_len - i;
                                 let back = k - remaining;
@@ -355,6 +393,7 @@ fn mutated_positions(peptide: &str, matched: &str) -> String {
     format!("[{}]", v.join(", "))
 }
 
+/// Reported coordinates are 1-based and inclusive.
 fn hit_record(query_id: &str, peptide: &str, matched_seq: &str, mismatches: usize, encoded_start: u64) -> HitRecord {
     let protein_number = (encoded_start / PROTEIN_INDEX_MULTIPLIER) as u32;
     let position = (encoded_start % PROTEIN_INDEX_MULTIPLIER) as usize;
@@ -432,6 +471,9 @@ fn unzip_records(records: Vec<HitRecord>) -> Columns {
     (qid, qseq, matched, pnum, mm, mutated, s, e)
 }
 
+/// Discontinuous search: queries are (residue, 1-based position) constraints with no
+/// contiguous k-mer to look up, so this scans every protein, touching only the requested
+/// positions in each.
 pub(crate) fn run_discontinuous(
     pepidx_path: &str,
     epitopes: Vec<(String, Vec<(char, usize)>)>,
@@ -565,9 +607,13 @@ fn is_terminal_deletion(q_idx: isize, query_len: usize, p_idx: isize, protein_le
     false
 }
 
-// `allow_del` / `allow_ins` mask the edit branches so a single alignment uses deletions
-// OR insertions, never both. extend_bidirectional fixes the mask for a seed's two
-// extensions, which is what stops a left-deletion mixing with a right-insertion.
+/// Depth-first extension from a seed. Walks `direction` (+1 right, -1 left) consuming query
+/// and protein characters, and returns how many PROTEIN characters each surviving path
+/// consumed — that count is what turns into the matched substring's bounds.
+///
+/// `allow_del` / `allow_ins` mask the edit branches so a single alignment uses deletions
+/// OR insertions, never both. extend_bidirectional fixes the mask for a seed's two
+/// extensions, which is what stops a left-deletion mixing with a right-insertion.
 fn dfs(
     query: &[u8],
     q_idx: isize,
@@ -675,6 +721,8 @@ fn extend_bidirectional(
     results
 }
 
+/// Dedup is by (protein, start, matched) because different seeds reach the same alignment.
+/// The `mismatches` field carries the indel count here, reusing the column.
 fn indel_search_peptide(
     query_id: &str,
     peptide: &str,
@@ -744,6 +792,8 @@ fn indel_search_peptide(
     }
 }
 
+// Entry points called from lib.rs. Each opens the index once and fans queries out over rayon;
+// the index is shared immutably, so no synchronization is needed.
 pub(crate) fn run_indel(
     pepidx_path: &str,
     peptides: Vec<(String, String)>,
@@ -777,8 +827,8 @@ pub(crate) fn run(pepidx_path: &str, peptides: Vec<(String, String)>, k: usize, 
     unzip_records(records)
 }
 
-// ── Counts-only path (aggregate; O(unique queries), no per-hit materialization) ──
-
+// ── Counts-only path: same matching, tallies per mismatch level instead of materializing
+// hits, so memory scales with queries rather than hits. ──
 pub(crate) type CountColumns = (Vec<String>, Vec<String>, Vec<i64>, Vec<u64>);
 
 /// Tally accepted matches per mismatch level for one peptide, mirroring

--- a/pepmatch/rs-engine/src/preprocess.rs
+++ b/pepmatch/rs-engine/src/preprocess.rs
@@ -1,7 +1,12 @@
+//! Builds the `.pepidx` that all searching reads. Layout is documented at `write_pepidx`;
+//! match.rs mirrors it byte for byte, so a change here needs the same change there.
+
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write, BufWriter, Read, Seek, SeekFrom};
 
+// Every k-mer occurrence is stored as ONE u64: protein_number * MULTIPLIER + offset, so the
+// multiplier is also the hard cap on protein length.
 const PROTEIN_INDEX_MULTIPLIER: u64 = 100_000_000;
 
 struct Protein {
@@ -99,6 +104,7 @@ fn is_swissprot(header: &str) -> bool {
     header.starts_with("sp|")
 }
 
+/// UniProt marks isoforms with a dash suffix (`P12345-2`).
 fn has_isoform_dash(protein_id: &str) -> bool {
     protein_id.contains('-')
 }
@@ -114,6 +120,8 @@ fn base_accession(protein_id: &str) -> &str {
 fn extract_all_metadata(proteins: &[Protein]) -> Vec<Metadata> {
     let mut canonical_pe: HashMap<String, String> = HashMap::new();
 
+    // Pass 1: isoform records often omit PE (protein existence) level and inherit their
+    // canonical entry's, which may appear later in the file.
     for protein in proteins {
         let pid = extract_protein_id(&protein.header);
         if !has_isoform_dash(&pid) {
@@ -127,6 +135,7 @@ fn extract_all_metadata(proteins: &[Protein]) -> Vec<Metadata> {
     let mut seen_genes: HashSet<String> = HashSet::new();
     let mut metadata_list: Vec<Metadata> = Vec::with_capacity(proteins.len());
 
+    // `seen_genes` makes gene_priority "first entry wins": one preferred protein per gene.
     for protein in proteins {
         let h = &protein.header;
         let protein_id = extract_protein_id(h);
@@ -182,8 +191,11 @@ fn write_length_prefixed(buf: &mut Vec<u8>, s: &str) {
     buf.extend_from_slice(bytes);
 }
 
+/// Records are `[k bytes of k-mer][u32 count][count * u64 position]`.
 fn write_kmer_chunk(kmer_map: HashMap<u128, Vec<u64>>, chunk_path: &str, k: usize) -> u64 {
     let mut sorted: Vec<(u128, Vec<u64>)> = kmer_map.into_iter().collect();
+    // Sorting the u128 sorts the k-mers lexicographically: the k-mer is packed big-endian,
+    // one residue byte per byte, so numeric order and byte order agree. (Requires k <= 16.)
     sorted.sort_unstable_by_key(|a| a.0);
 
     let file = File::create(chunk_path).expect("Cannot create chunk file");
@@ -252,10 +264,17 @@ impl ChunkReader {
     }
 }
 
+/// Layout, in order: 8-byte magic, k (u8), protein count (u32), sequence length (u64),
+/// unique k-mer count (u64), total positions (u64), metadata length (u64); then the
+/// concatenated sequences, protein offsets, metadata offsets, metadata blob, k-mer offsets,
+/// k-mer data. Every section start is derivable from the fixed-size header, which is what
+/// lets the query side mmap the file and binary-search it without parsing.
 fn write_pepidx(path: &str, k: usize, proteins: &[Protein], metadata_list: &[Metadata]) {
     let file = File::create(path).expect("Cannot create output file");
     let mut writer = BufWriter::new(file);
 
+    // Sequences live end to end in one buffer; `protein_offsets` is the only record of where
+    // each protein begins, so query-side bounds checks all go through it.
     let mut concat_seq = Vec::new();
     let mut protein_offsets: Vec<u64> = Vec::with_capacity(proteins.len());
     for protein in proteins {
@@ -263,6 +282,8 @@ fn write_pepidx(path: &str, k: usize, proteins: &[Protein], metadata_list: &[Met
         concat_seq.extend_from_slice(protein.sequence.as_bytes());
     }
 
+    // External sort, to bound peak memory on proteome-scale input: 50k proteins at a time,
+    // each batch sorted and spilled to its own chunk file, then k-way merged below.
     let chunk_size = 50_000;
     let mut chunk_paths: Vec<String> = Vec::new();
     let mut total_positions: u64 = 0;
@@ -310,6 +331,8 @@ fn write_pepidx(path: &str, k: usize, proteins: &[Protein], metadata_list: &[Met
         write_length_prefixed(&mut metadata_buf, &meta.swissprot);
     }
 
+    // K-way merge: take the smallest k-mer at any cursor and concatenate the position lists
+    // of every chunk holding it, giving one sorted run with each k-mer appearing once.
     let mut readers: Vec<ChunkReader> = chunk_paths.iter()
         .map(|p| ChunkReader::new(p, k))
         .collect();
@@ -358,6 +381,8 @@ fn write_pepidx(path: &str, k: usize, proteins: &[Protein], metadata_list: &[Met
         std::fs::remove_file(chunk_path).ok();
     }
 
+    // Final pass records where each k-mer's record starts — the table the query-side binary
+    // search indexes into.
     let mut merged_reader = ChunkReader::new(&merged_path, k);
     let mut kmer_offsets: Vec<u64> = Vec::with_capacity(num_unique_kmers as usize);
     let mut kmer_data: Vec<u8> = Vec::new();


### PR DESCRIPTION
Comments only. `cargo build` clean, 149 tests pass against a rebuilt extension.

Kept to the points that can't be worked out from reading the code:

**preprocess.rs**
- The `protein_number * MULTIPLIER + offset` encoding and the protein-length cap it implies.
- The `.pepidx` layout, with the note that match.rs mirrors it byte for byte.
- That k-mer collection is an external sort (50k-protein chunks spilled to disk, k-way merged).
- Why sorting the packed `u128` gives lexicographic k-mer order.
- Why the metadata scan needs two passes (isoform PE inheritance; first-entry-wins gene priority).

**match.rs**
- Why `unsafe impl Sync` is sound.
- `lookup` binary-searches raw bytes because the writer sorted them and they're fixed width.
- Exact search as seed voting.
- Mismatch search: the pigeonhole reason one k-mer must be exact, the two length regimes (whole-tile vs per-residue verification), and the `back` overlap trick for the tail tile.
- The `100` return in the verification helpers means reject.
- Discontinuous search scans every protein because there's no contiguous k-mer to look up.
- Merged the pre-existing split comment above `dfs` into one doc comment.

**lib.rs** — the PyO3 boundary and why output is columnar; why `match.rs` needs `#[path]`.
